### PR TITLE
Build Cython extensions during pip install

### DIFF
--- a/pyfaceau/__init__.py
+++ b/pyfaceau/__init__.py
@@ -5,7 +5,7 @@ A complete Python implementation of OpenFace 2.2's AU extraction pipeline
 with high-performance parallel processing support and CLNF landmark refinement.
 """
 
-__version__ = "1.3.11"
+__version__ = "1.3.12"
 
 # Weight management functions can be imported without heavy dependencies
 from .download_weights import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel"]
+requires = ["setuptools>=45", "wheel", "Cython>=3.0", "numpy>=1.20.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyfaceau"
-version = "1.3.11"
+version = "1.3.12"
 description = "Pure Python OpenFace 2.2 AU extraction with CLNF landmark refinement"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,41 @@
 setup.py for pyfaceau - Pure Python OpenFace 2.2 AU Extraction
 """
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Extension
 from pathlib import Path
 
 # Read long description from README
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
+
+# Cython extensions for performance-critical paths.
+# These compile from .pyx sources during `pip install` so that PyPI installs
+# get the same fast paths as local editable installs. If Cython or numpy is
+# unavailable at build time, the package still installs and falls back to the
+# pure-Python implementations at runtime (see pipeline.py imports).
+ext_modules = []
+try:
+    from Cython.Build import cythonize
+    import numpy as np
+    ext_modules = cythonize(
+        [
+            Extension(
+                name="pyfaceau.cython_histogram_median",
+                sources=["pyfaceau/utils/cython_extensions/cython_histogram_median.pyx"],
+                include_dirs=[np.get_include()],
+            ),
+            Extension(
+                name="pyfaceau.cython_rotation_update",
+                sources=["pyfaceau/utils/cython_extensions/cython_rotation_update.pyx"],
+                include_dirs=[np.get_include()],
+            ),
+        ],
+        compiler_directives={"language_level": "3"},
+    )
+except ImportError:
+    # Cython/numpy not available at build time; runtime will fall back to
+    # pure-Python implementations.
+    pass
 
 setup(
     name="pyfaceau",
@@ -82,7 +111,15 @@ setup(
     scripts=['pyfaceau_gui.py'],
     include_package_data=True,
     package_data={
-        "pyfaceau": ["*.txt", "*.json"],
+        "pyfaceau": [
+            "*.txt",
+            "*.json",
+            # Ship .pyx sources alongside the compiled .so files so users can
+            # rebuild from source if needed.
+            "utils/cython_extensions/*.pyx",
+            "utils/cython_extensions/*.pxd",
+        ],
     },
+    ext_modules=ext_modules,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
 
 setup(
     name="pyfaceau",
-    version="1.3.11",
+    version="1.3.12",
     author="John Wilson",
     author_email="",  # Add email if desired
     description="Pure Python OpenFace 2.2 AU extraction with PyMTCNN face detection and CLNF refinement",


### PR DESCRIPTION
## Summary

Compiles the two `.pyx` sources during `pip install` so PyPI / sdist installs get the same fast Cython paths that local editable installs have. Without this, fresh installs silently fall back to pure-Python implementations of the histogram median tracker and rotation update — functional but **~10–20× slower** for the running-median operation, and may differ numerically due to floating-point order-of-operations differences.

## Changes

- **`pyproject.toml`**: add `Cython>=3.0` and `numpy>=1.20.0` to `[build-system].requires` so they're available during `pip install` from sdist
- **`setup.py`**:
  - define `ext_modules` via `cythonize()` for the two `.pyx` files in `pyfaceau/utils/cython_extensions/`
  - build them as `pyfaceau.cython_histogram_median` and `pyfaceau.cython_rotation_update` to match existing import paths in `pipeline.py`
  - keep the `ImportError` fallback so the package still installs if Cython is unavailable; runtime continues to fall back to pure Python in that case
  - extend `package_data` to ship `.pyx` and `.pxd` sources alongside the compiled `.so` files for source rebuilds

## Test plan

- [x] Local: `python setup.py build_ext --inplace` produces the expected `.so` files
- [x] Local: `python -m build --sdist` succeeds; sdist contains both `.pyx` sources and the build hooks
- [ ] Fresh venv: `pip install pyfaceau` (after this lands and a new release is cut) verifies that installed wheels contain the compiled `.so` files
- [ ] Sanity-check that the imports `from pyfaceau.cython_histogram_median import …` resolve to the compiled module rather than the pure-Python fallback (see `pipeline.py` imports)

## Why now

This is the first pyfaceau commit on a feature branch since the manuscript-era code; the production-2026-05-01 milestone validation depends on the fast Cython paths being present (the running-median bug investigation was a major time sink). Locking in the build infrastructure now prevents the silent fallback from regressing future installs.